### PR TITLE
Fix auto uninstall pth

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[report]
-fail_under=0
-show_missing=True
-skip_covered=True
-sort=Miss

--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-[flake8]
-ignore = E203, E266, E501, W503, F811, N802
-max-line-length = 88
-max-complexity = 18
-select = B,C,E,F,W,T4,B9,N
-exclude=
-    src/py/tests/test_idom/test_codec/html_coding.py
-    src/js

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-known_third_party = docopt,setuptools,typing_extensions

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include pyalect/pth.embed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pyalect
 
-Dynamically transpiling Python dialect for good.
+A dynamic dialect transpiler for Python.
 
 
 # Installation
@@ -8,6 +8,7 @@ Dynamically transpiling Python dialect for good.
 ```bash
 pip install pyalect
 ```
+
 
 # Read The Docs
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 Pyalect |release|
 =================
 
-Dynamically transpiling Python dialect for good.
+A dynamic dialect transpiler for Python.
 
 .. toctree::
     :maxdepth: 1
@@ -60,7 +60,7 @@ Console Usage
     * - ``pyalect show config``
       - Prints the configuration file path and current state.
     * - ``pyalect delete config``
-      - Deletes the config file. This should be done prior to uninstalling Pyalect.
+      - Deleting the configuration file will also effectively deactivate Pyalect.
 
 
 Console Examples

--- a/pyalect/__init__.py
+++ b/pyalect/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0.dev2"
+__version__ = "0.1.0.dev3"
 from . import importer, shims
 from .config import activate, deactivate, path
 from .dialect import Transpiler, deregister, register

--- a/pyalect/config.py
+++ b/pyalect/config.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 
 import pyalect
 
+_HERE = Path(__file__).parent
 _CONFIG: Optional[Dict[str, Any]] = None
 
 
@@ -70,7 +71,8 @@ def _write_file(config: Dict[str, Any]) -> None:
     lines = []
     if config["active"]:
         # only import pyalect if active
-        lines.append("import pyalect")
+        with open(_HERE / "pth.embed") as pth_src:
+            lines.append("import os; exec(%r)" % pth_src.read())
     serialized = json.dumps(config)
     lines.append(f"# {serialized}")
     with open(path(), "w+") as pth:

--- a/pyalect/console.py
+++ b/pyalect/console.py
@@ -39,8 +39,7 @@ def main(arguments: Dict[str, Any]) -> None:
         pyalect show config:
             Prints the configuration file path and current state.
         pyalect delete config:
-            Should be done prior to uninstalling Pyalect. This has the effect of
-            deactivating Pyalect and clearing the configuration state.
+            Deleting the configuration file will also effectively deactivate Pyalect.
     """
     try:
         for output in execute(arguments):

--- a/pyalect/pth.embed
+++ b/pyalect/pth.embed
@@ -1,0 +1,9 @@
+# this file is embeded into the .pth file
+try:
+    import pyalect
+except ImportError as error:
+    if str(error) == "No module named 'pyalect'":
+        # silently remove .pth file (pyalect was uninstalled)
+        import os
+        from distutils.sysconfig import get_python_lib
+        os.remove(os.path.join(get_python_lib(), "pyalect.pth"))

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,3 +2,4 @@ jupyter
 pre-commit
 notebook
 twine
+setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,24 @@
+[tool:pytest]
+ignore = E203, E266, E501, W503, F811, N802
+max-line-length = 88
+max-complexity = 18
+select = B,C,E,F,W,T4,B9,N
+addopts = --cov=pyalect
+
+[coverage:report]
+fail_under=0
+show_missing=True
+skip_covered=True
+sort=Miss
+
+[flake8]
+ignore = E203, E266, E501, W503, F811, N802
+max-line-length = 88
+max-complexity = 18
+select = B,C,E,F,W,T4,B9,N
+
+[bdist_wheel]
+universal = True
+
+[tool:isort]
+known_third_party = docopt,setuptools,typing_extensions


### PR DESCRIPTION
The pth file will now automatically remove itself if an import of `pyalect` fails with a specific message.

There may be a better solution similar to what `pytest-cov` uses with their `.pth` file, but I couldn't get it to work:

https://github.com/pytest-dev/pytest-cov/blob/master/setup.py

Also consolidates various "dot" files into `setup.cfg`