### PR TITLE
Raise errors with specific file locations when importing.

### DIFF
--- a/pyalect/__init__.py
+++ b/pyalect/__init__.py
@@ -1,5 +1,15 @@
-__version__ = "0.1.0.dev9"
+__version__ = "0.1.0.dev10"
 from . import importer, shims
-from .dialect import Dialect, deregister, register, registered
+from .dialect import Dialect, apply_dialects, deregister, register, registered
+from .errors import DialectError
 
-__all__ = ["deregister", "importer", "register", "registered", "shims", "Dialect"]
+__all__ = [
+    "apply_dialects",
+    "deregister",
+    "DialectError",
+    "importer",
+    "register",
+    "registered",
+    "shims",
+    "Dialect",
+]

--- a/pyalect/errors.py
+++ b/pyalect/errors.py
@@ -1,0 +1,70 @@
+import sys
+from types import CodeType
+from typing import Any, Optional
+
+
+class DialectError(Exception):
+    """Base error for dialects."""
+
+    def __init__(
+        self, error: Any, filename: Optional[str] = None, line: Optional[int] = None
+    ) -> None:
+        super().__init__(error)
+        self.filename = filename or "<string>"
+        self.line = line or 1
+
+
+def reraise_dialect_error() -> None:
+    """Reraise an exception """
+    exc_info = sys.exc_info()
+
+    if exc_info[1] is None:
+        raise RuntimeError(
+            "No error to reraise - this function must be used inside an 'except:' block"
+        )
+    if not isinstance(exc_info[1], DialectError):
+        raise TypeError(f"Exception must be a 'DialectError', not {exc_info[1]}")
+
+    exc_value: DialectError = exc_info[1]
+
+    # and fake the exception
+    line_shift = "\n" * (exc_value.line - 1)
+    raise_expr = "raise RuntimeError('dialect failed')"
+    code = compile(line_shift + raise_expr, exc_value.filename, "exec")
+
+    if exc_value.__traceback__ is not None:
+        location = exc_value.__traceback__.tb_frame.f_code.co_name
+        # depending on implementation changing the
+        # location might not work so we have to try it
+        try:
+            code = CodeType(
+                0,
+                code.co_kwonlyargcount,
+                code.co_nlocals,
+                code.co_stacksize,
+                code.co_flags,
+                code.co_code,
+                code.co_consts,
+                code.co_names,
+                code.co_varnames,
+                exc_value.filename,
+                location,
+                code.co_firstlineno,
+                code.co_lnotab,
+                (),
+                (),
+            )
+        except Exception:
+            pass
+
+    # execute the code and catch the new traceback
+    try:
+        exec(code, {}, {})
+    except Exception:
+        new_exc_info = sys.exc_info()
+        if new_exc_info[2] is None:
+            raise RuntimeError("Failed to re-raise") from exc_value
+        new_tb = new_exc_info[2].tb_next
+
+    # return without this frame
+    raise exc_value.with_traceback(new_tb)

--- a/pyalect/importer.py
+++ b/pyalect/importer.py
@@ -10,6 +10,7 @@ from types import CodeType
 from typing import Dict, List, Optional, Sequence, Union
 
 from .dialect import apply_dialects, find_file_dialects
+from .errors import DialectError, reraise_dialect_error
 
 
 def decode_source(source_bytes: bytes) -> str:
@@ -34,9 +35,11 @@ class PyalectLoader(SourceFileLoader):
             source = decode_source(data)
         else:
             source = data
-        code: CodeType = compile(
-            apply_dialects(source, self.dialects, path), path, "exec"
-        )
+        try:
+            ast_tree = apply_dialects(source, self.dialects, path)
+        except DialectError:
+            reraise_dialect_error()
+        code: CodeType = compile(ast_tree, path, "exec")
         return code
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ select = B,C,E,F,W,T4,B9,N
 addopts = --cov=pyalect
 
 [coverage:report]
-fail_under=92
+fail_under=93
 show_missing=True
 skip_covered=True
 sort=Miss

--- a/tests/mock_package/empty.py
+++ b/tests/mock_package/empty.py
@@ -1,0 +1,2 @@
+# dialect=test_dialect
+x = 1

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -69,7 +69,7 @@ def test_no_dialect_found_in_source(source):
 
 
 def test_file_has_no_dialect():
-    no_dialect_file = Path(__file__).parents[0] / "mock_package" / "no_dialect"
+    no_dialect_file = Path(__file__).parent / "mock_package" / "no_dialect"
     assert find_file_dialects(no_dialect_file) == []
 
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,13 +1,13 @@
-from pyalect import Dialect
+import re
+import traceback
+
+from pyalect import Dialect, DialectError
 
 
 def test_imports():
     class MyDialect(Dialect):
 
         name = "test"
-
-        def __init__(self, dialect):
-            self.dialect = dialect
 
         def transform_src(self, source):
             return source.replace("x", "y")
@@ -19,3 +19,26 @@ def test_imports():
 
     # the name x has been replaced with y
     assert comment_header.y == 1
+
+
+_tb_template = r""".*
+  File ".*?/mock_package/empty.py", line 1, in source_to_code
+    # dialect=test_dialect
+pyalect.errors.DialectError: error_message
+"""
+
+
+def test_raise_dialect_error_on_import():
+    class MyDialect(Dialect):
+
+        name = "test_dialect"
+
+        def transform_src(self, source):
+            raise DialectError("error_message", self.filename, 1)
+
+    try:
+        from .mock_package import empty  # noqa
+    except Exception:
+        assert bool(re.match(_tb_template, traceback.format_exc(), re.DOTALL))
+    else:
+        assert False, f"Did not raise {DialectError}"


### PR DESCRIPTION
Errors which occur while importing a file can now have a custom error location if thrown with a `DialectError`.